### PR TITLE
Fix patient selection persistence across tabs

### DIFF
--- a/anamnesis.js
+++ b/anamnesis.js
@@ -1,49 +1,29 @@
-// Beispiel-Daten für archivierte Patienten
-const anamnesisData = {
-  1: {
-    name: 'Anna Musterfrau',
-    points: [
-      'Patientin berichtet über häufigen Durst und Harndrang seit 2 Monaten',
-      'Erhöhte Müdigkeit und Gewichtsverlust von ca. 5 kg',
-      'Diagnose: Neu diagnostizierter Diabetes Typ II',
-      'Bisherige Maßnahmen: Blutzuckermessung durchgeführt, Ernährungsberatung eingeleitet',
-    ]
-  },
-  2: {
-    name: 'Max Mustermann',
-    points: [
-      'Patient klagt über wiederkehrende Atemnot bei Belastung',
-      'Dokumentierte Asthmaanfälle in der Kindheit',
-      'Aktuell: Inhalationstherapie mit Salbutamol',
-      'Bisherige Maßnahmen: Lungenfunktionstest und Allergietest geplant',
-    ]
-  }
-};
+function loadPatient(id) {
+  const list = JSON.parse(localStorage.getItem('patientRecords') || '[]');
+  return list.find(p => p.id === id);
+}
 
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('anamnesisContainer');
   const headerDisplay = document.getElementById('currentPatientDisplay');
-  // Ausgewählten Patienten aus LocalStorage holen
   const id = parseInt(localStorage.getItem('currentPatientId'), 10);
 
-  if (!id || !anamnesisData[id]) {
+  const patient = loadPatient(id);
+  if (!patient) {
     headerDisplay.textContent = 'keiner ausgewählt';
     container.innerHTML = '<p>Kein Patient ausgewählt oder keine Anamnese vorhanden.</p>';
     return;
   }
 
-  const data = anamnesisData[id];
-  // Header aktualisieren
-  headerDisplay.textContent = data.name;
+  headerDisplay.textContent = `${patient.first} ${patient.last}`;
 
-  // Anamnese anzeigen
+  const notes = patient.sections?.anamnesis || '';
+
   const section = document.createElement('div');
   section.className = 'patient-section';
   section.innerHTML = `
-    <h3>${data.name}</h3>
-    <ul>
-      ${data.points.map(pt => `<li>${pt}</li>`).join('')}
-    </ul>
+    <h3>${patient.first} ${patient.last}</h3>
+    <p>${notes ? notes.replace(/\n/g, '<br>') : 'Keine Einträge.'}</p>
   `;
   container.appendChild(section);
 });

--- a/dictation.html
+++ b/dictation.html
@@ -1,2 +1,21 @@
-<h2>dictation Page</h2>
-<p>This is a placeholder for the dictation section.</p>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Dictation</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    textarea { width: 100%; box-sizing: border-box; margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <h2>Diktierfunktion</h2>
+  <textarea id="transcript" rows="10" placeholder="Transkription..."></textarea>
+  <div>
+    <button id="startBtn">Aufnahme starten</button>
+    <button id="stopBtn">Stop</button>
+  </div>
+  <p id="status"></p>
+  <script src="dictation.js"></script>
+</body>
+</html>

--- a/dictation.js
+++ b/dictation.js
@@ -1,0 +1,54 @@
+let recognition;
+
+function getCurrentPatient() {
+  const id = parseInt(localStorage.getItem('currentPatientId'), 10);
+  const list = JSON.parse(localStorage.getItem('patientRecords') || '[]');
+  return list.find(p => p.id === id);
+}
+
+function savePatient(patient) {
+  const list = JSON.parse(localStorage.getItem('patientRecords') || '[]');
+  const idx = list.findIndex(p => p.id === patient.id);
+  if (idx !== -1) {
+    list[idx] = patient;
+    localStorage.setItem('patientRecords', JSON.stringify(list));
+  }
+}
+
+document.getElementById('startBtn').onclick = () => {
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (!SpeechRecognition) {
+    document.getElementById('status').textContent = 'Browser unterstützt keine Spracherkennung.';
+    return;
+  }
+  recognition = new SpeechRecognition();
+  recognition.lang = 'de-DE';
+  recognition.interimResults = false;
+  recognition.onresult = e => {
+    const text = e.results[0][0].transcript;
+    const speaker = text.toLowerCase().includes('patient') ? 'Patient' : 'Arzt';
+    const line = `${speaker}: ${text}`;
+    const area = document.getElementById('transcript');
+    area.value += line + '\n';
+
+    const patient = getCurrentPatient();
+    if (patient) {
+      patient.sections = patient.sections || {};
+      patient.sections.anamnesis = (patient.sections.anamnesis || '') + line + '\n';
+      savePatient(patient);
+    }
+  };
+  recognition.onerror = err => {
+    document.getElementById('status').textContent = 'Fehler: ' + err.error;
+  };
+  recognition.onend = () => {
+    document.getElementById('status').textContent = 'Aufnahme beendet.';
+  };
+  recognition.start();
+  document.getElementById('status').textContent = 'Spracheingabe läuft...';
+};
+
+document.getElementById('stopBtn').onclick = () => {
+  if (recognition) recognition.stop();
+};
+

--- a/general-info.js
+++ b/general-info.js
@@ -1,9 +1,53 @@
 const infoContainer = document.getElementById('infoContainer');
-const patientLog = [
-  { id: 1, first:'Anna', last:'Musterfrau', dob:'1975-05-12', city:'Hamburg', history:'Diabetes Typ II seit 2010', tests:'Blutzucker-Kontrolle: done\nAugenarzt: pending' },
-  { id: 2, first:'Max', last:'Mustermann', dob:'1982-10-23', city:'Berlin', history:'Asthma bronchiale seit Kindheit', tests:'Lungenfunktionstest: done\nAllergietest: pending' }
-];
-let nextId = 3;
+
+let patientLog = [];
+let nextId = 1;
+
+function loadPatients() {
+  const stored = localStorage.getItem('patientRecords');
+  if (stored) {
+    patientLog = JSON.parse(stored);
+    nextId = patientLog.reduce((max, p) => Math.max(max, p.id), 0) + 1;
+  } else {
+    patientLog = [
+      {
+        id: 1,
+        first: 'Anna',
+        last: 'Musterfrau',
+        dob: '1975-05-12',
+        city: 'Hamburg',
+        history: 'Diabetes Typ II seit 2010',
+        tests: 'Blutzucker-Kontrolle: done\nAugenarzt: pending',
+        sections: { anamnesis: '', diagnosis: '', treatment: '', review: '', export: '' }
+      },
+      {
+        id: 2,
+        first: 'Max',
+        last: 'Mustermann',
+        dob: '1982-10-23',
+        city: 'Berlin',
+        history: 'Asthma bronchiale seit Kindheit',
+        tests: 'Lungenfunktionstest: done\nAllergietest: pending',
+        sections: { anamnesis: '', diagnosis: '', treatment: '', review: '', export: '' }
+      }
+    ];
+    nextId = 3;
+    localStorage.setItem('patientRecords', JSON.stringify(patientLog));
+  }
+}
+
+function savePatients() {
+  localStorage.setItem('patientRecords', JSON.stringify(patientLog));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadPatients();
+  const id = parseInt(localStorage.getItem('currentPatientId'), 10);
+  if (id) {
+    const p = patientLog.find(pt => pt.id === id);
+    if (p) renderPatientBox(p);
+  }
+});
 
 function showAddPatientForm() {
   document.getElementById('patientModal').style.display = 'flex';
@@ -20,12 +64,21 @@ function addPatient() {
   const history = document.getElementById('history').value;
   const tests   = document.getElementById('tests').value;
 
-  // Box anzeigen
-  infoContainer.innerHTML = '';
-  renderPatientBox({ first, last, dob, city, history, tests });
+  const patient = {
+    id: nextId++,
+    first,
+    last,
+    dob,
+    city,
+    history,
+    tests,
+    sections: { anamnesis: '', diagnosis: '', treatment: '', review: '', export: '' }
+  };
 
-  // Log
-  patientLog.push({ id: nextId++, first, last, dob, city, history, tests });
+  patientLog.push(patient);
+  savePatients();
+
+  selectPatient(patient);
   hideAddPatientForm();
 }
 
@@ -47,13 +100,19 @@ function showArchivedModal() {
     li.style.padding = '8px';
     li.style.cursor = 'pointer';
     li.textContent = `${p.first} ${p.last}`;
-    li.onclick = () => { hideArchiveModal(); renderPatientBox(p); };
+    li.onclick = () => { hideArchiveModal(); selectPatient(p); };
     list.appendChild(li);
   });
   document.getElementById('archiveModal').style.display = 'flex';
 }
 function hideArchiveModal() {
   document.getElementById('archiveModal').style.display = 'none';
+}
+
+function selectPatient(p) {
+  localStorage.setItem('currentPatientId', p.id);
+  renderPatientBox(p);
+  savePatients();
 }
 
 function renderPatientBox(p) {


### PR DESCRIPTION
## Summary
- persist selected patient ID in localStorage
- use stored ID on page load to display the last selected patient
- ensure archive selections also update localStorage
- store all patients in localStorage and add default templates
- implement dictation page with speech recognition that appends to anamnesis notes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859c864af648322b38e90aa552d783c