### PR TITLE
Refactor patient storage logic

### DIFF
--- a/Diagnosis.js
+++ b/Diagnosis.js
@@ -2,21 +2,6 @@
 let recognition;
 let isRecording = false;
 
-function getCurrentPatient() {
-  const id = parseInt(localStorage.getItem('currentPatientId'), 10);
-  const list = JSON.parse(localStorage.getItem('patientRecords') || '[]');
-  return list.find(p => p.id === id);
-}
-
-function savePatient(patient) {
-  const list = JSON.parse(localStorage.getItem('patientRecords') || '[]');
-  const idx = list.findIndex(p => p.id === patient.id);
-  if (idx !== -1) {
-    list[idx] = patient;
-    localStorage.setItem('patientRecords', JSON.stringify(list));
-  }
-}
-
 function updateUI() {
   document.getElementById('startBtn').disabled = isRecording;
   document.getElementById('stopBtn').disabled  = !isRecording;
@@ -39,6 +24,7 @@ function startRecognition() {
     if (patient) {
       patient.sections = patient.sections || {};
       patient.sections.anamnesis = (patient.sections.anamnesis || '') + line + '\n';
+      patient.sections.diagnosisResults = (patient.sections.diagnosisResults || '') + line + '\n';
       savePatient(patient);
     }
   };

--- a/anamnesis.html
+++ b/anamnesis.html
@@ -14,6 +14,7 @@
     <p>Kein Patient ausgewählt.</p>
   </div>
 
+  <script src="patient-store.js"></script>
   <script src="common.js"></script>
   <script src="anamnesis.js"></script>
 </body>

--- a/anamnesis.js
+++ b/anamnesis.js
@@ -2,9 +2,7 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('anamnesisContainer');
-  const id = parseInt(localStorage.getItem('currentPatientId'), 10);
-  const patientList = JSON.parse(localStorage.getItem('patientRecords') || '[]');
-  const patient = patientList.find(p => p.id === id);
+  const patient = patientStore.getCurrentPatient();
 
   if (!patient) {
     container.innerHTML = '<p>Kein Patient ausgewählt.</p>';

--- a/common.js
+++ b/common.js
@@ -1,9 +1,4 @@
 // common.js
-function getCurrentPatient() {
-  const id = parseInt(localStorage.getItem('currentPatientId'), 10);
-  const list = JSON.parse(localStorage.getItem('patientRecords') || '[]');
-  return list.find(p => p.id === id);
-}
 
 /**
  * Rendert die Sektion aus patient.sections[sectionKey] in das Element containerId.

--- a/diagnosis-summary.html
+++ b/diagnosis-summary.html
@@ -4,6 +4,7 @@
 <body>
   <div id="content"></div>
 
+  <script src="patient-store.js"></script>
   <script src="common.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/diagnosis.html
+++ b/diagnosis.html
@@ -22,6 +22,7 @@
   <div id="content">
     <!-- Dynamisch eingefügt via analysis.js -->
   </div>
+  <script src="patient-store.js"></script>
   <script src="Diagnosis.js"></script>
   <script src="common.js"></script>
 

--- a/dictation.html
+++ b/dictation.html
@@ -26,6 +26,7 @@
     </div>
     <p id="status">Bereit.</p>
   </div>
+  <script src="patient-store.js"></script>
   <script src="dictation.js"></script>
   <script src="common.js"></script>
 

--- a/dictation.js
+++ b/dictation.js
@@ -29,11 +29,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const line = `${isPatient ? 'Patient' : 'Arzt'}: ${text}`;
       area.value += line + '\n';
 
-      // Speichern in patient.sections.anamnesis
+      // Speichern im Patientenprotokoll
       const patient = getCurrentPatient();
       if (patient) {
         patient.sections = patient.sections || {};
         patient.sections.anamnesis = (patient.sections.anamnesis || '') + line + '\n';
+        patient.sections.analysisProtocol = (patient.sections.analysisProtocol || '') + line + '\n';
         savePatient(patient);
       }
     };
@@ -58,19 +59,3 @@ document.addEventListener('DOMContentLoaded', () => {
   updateUI();
   status.textContent = 'Bereit.';
 });
-
-// Hilfsfunktionen (aus common.js oder dictation-spezifisch)
-function getCurrentPatient() {
-  const id = parseInt(localStorage.getItem('currentPatientId'), 10);
-  const list = JSON.parse(localStorage.getItem('patientRecords') || '[]');
-  return list.find(p => p.id === id);
-}
-
-function savePatient(p) {
-  const list = JSON.parse(localStorage.getItem('patientRecords') || '[]');
-  const idx = list.findIndex(x => x.id === p.id);
-  if (idx !== -1) {
-    list[idx] = p;
-    localStorage.setItem('patientRecords', JSON.stringify(list));
-  }
-}

--- a/general-info.html
+++ b/general-info.html
@@ -94,6 +94,7 @@
     </div>
   </div>
 
+  <script src="patient-store.js"></script>
   <script src="general-info.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -144,6 +144,7 @@
       padding: 100px 30px 30px 30px;
     }
   </style>
+  <script src="patient-store.js"></script>
   <script src="common.js"></script>
 
   <script>

--- a/patient-store.js
+++ b/patient-store.js
@@ -1,0 +1,83 @@
+const STORAGE_KEY = 'patientRecords';
+let patientList = [];
+let nextId = 1;
+
+function ensureSectionFields(p) {
+  p.sections = p.sections || {};
+  const defaults = {
+    anamnesis: '',
+    diagnosis: '',
+    treatment: '',
+    review: '',
+    export: '',
+    analysisProtocol: '',
+    diagnosisResults: '',
+    treatmentPlan: '',
+    diagnosisSummary: ''
+  };
+  for (const k in defaults) {
+    if (!Object.prototype.hasOwnProperty.call(p.sections, k)) {
+      p.sections[k] = defaults[k];
+    }
+  }
+  return p;
+}
+
+function loadPatients() {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  patientList = saved ? JSON.parse(saved) : [];
+  patientList.forEach(ensureSectionFields);
+  nextId = patientList.reduce((m, p) => Math.max(m, p.id), 0) + 1;
+}
+
+function savePatients() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(patientList));
+}
+
+function addPatient(p) {
+  p.id = nextId++;
+  ensureSectionFields(p);
+  p.archived = p.archived || false;
+  patientList.push(p);
+  savePatients();
+  return p;
+}
+
+function updatePatient(p) {
+  const idx = patientList.findIndex(x => x.id === p.id);
+  if (idx !== -1) {
+    patientList[idx] = ensureSectionFields(p);
+    savePatients();
+  }
+}
+
+function getPatientList() {
+  return patientList.slice();
+}
+
+function setCurrentPatient(id) {
+  localStorage.setItem('currentPatientId', id);
+}
+
+function getCurrentPatient() {
+  const id = parseInt(localStorage.getItem('currentPatientId'), 10);
+  return patientList.find(p => p.id === id);
+}
+
+// Initial load
+loadPatients();
+
+// expose globally
+window.patientStore = {
+  loadPatients,
+  savePatients,
+  addPatient,
+  updatePatient,
+  getPatientList,
+  getCurrentPatient,
+  setCurrentPatient
+};
+
+// for legacy callers
+window.getCurrentPatient = getCurrentPatient;
+window.savePatient = updatePatient;


### PR DESCRIPTION
## Summary
- centralize patient persistence in `patient-store.js`
- adapt modules to use the new store and keep extra fields for analysis, diagnosis, plan and summary
- inject `patient-store.js` into all pages so standalone views still work

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859e2640838832293e15e7af5bc78a4